### PR TITLE
Feat/add vault fields

### DIFF
--- a/abis/Vault.json
+++ b/abis/Vault.json
@@ -233,9 +233,15 @@
     },
     { "name": "UpdatePerformanceFee", "inputs": [{ "type": "uint256", "name": "performanceFee", "indexed": false }], "anonymous": false, "type": "event" },
     { "name": "UpdateManagementFee", "inputs": [{ "type": "uint256", "name": "managementFee", "indexed": false }], "anonymous": false, "type": "event" },
+    { "name": "UpdateManagement", "inputs": [{ "type": "address", "name": "management", "indexed": false }], "anonymous": false, "type": "event" },
+    { "name": "UpdateGuardian", "inputs": [{ "type": "address", "name": "guardian", "indexed": false }], "anonymous": false, "type": "event" },
+    { "name": "UpdateGovernance", "inputs": [{ "type": "address", "name": "governance", "indexed": false }], "anonymous": false, "type": "event" },
+    { "name": "UpdateDepositLimit", "inputs": [{ "type": "uint256", "name": "depositLimit", "indexed": false }], "anonymous": false, "type": "event" },
     { "name": "StrategyRemovedFromQueue", "inputs": [{ "type": "address", "name": "strategy", "indexed": true }], "anonymous": false, "type": "event" },
     { "name": "StrategyAddedToQueue", "inputs": [{ "type": "address", "name": "strategy", "indexed": true }], "anonymous": false, "type": "event" },
     { "name": "UpdateRewards", "inputs": [{ "type": "address", "name": "rewards", "indexed": false }], "anonymous": false, "type": "event" },
+    { "name": "management", "outputs": [{ "type": "address", "name": "" }], "inputs": [], "stateMutability": "view", "type": "function", "gas": 2981 },
+
     {
       "inputs": [
         {

--- a/schema.graphql
+++ b/schema.graphql
@@ -151,8 +151,6 @@ type Vault @entity {
   balanceTokensIdle: BigInt! # Tokens in the Vault contract
   "Balance of Tokens invested into Strategies"
   balanceTokensInvested: BigInt!
-  "Deposit limit for Tokens in the Vault"
-  tokensDepositLimit: BigInt!
   "Current supply of Shares"
   sharesSupply: BigInt!
   "Management fee in basis points"
@@ -171,6 +169,16 @@ type Vault @entity {
   apiVersion: String!
   "The vault's health check contract."
   healthCheck: HealthCheck
+  "The address authorized for guardian interactions in the new Vault"
+  guardian: Bytes!
+  "The management address of the Vault to assert privileged functions that can only be called by management"
+  management: Bytes!
+  "The governance address of the Vault to assert privileged functions that can only be called by governance"
+  governance: Bytes!
+  "The maximum amount of underlying that can be deposited"
+  availableDepositLimit: BigInt!
+  "The maximum amount of tokens that can be deposited in this Vault"
+  depositLimit: BigInt!
 }
 
 type VaultUpdate @entity {
@@ -199,7 +207,6 @@ type VaultUpdate @entity {
   "The current balance position defined as: (vault.totalAssets() * (vault.pricePerShare() / 10**vault.decimals()))."
   balancePosition: BigInt!
 
-
   ### PERFORMANCE
 
   "Returns generated in Tokens"
@@ -224,6 +231,20 @@ type VaultUpdate @entity {
   newRewards: Bytes
   "The vault's new health check contract. If this value has not been changed since the last VaultEvent, it will be null."
   newHealthCheck: HealthCheck
+  "The maximum amount of underlying that can be deposited"
+  availableDepositLimit: BigInt!
+  "The maximum amount of tokens that can be deposited in this Vault"
+  depositLimit: BigInt!
+
+  ### MANAGEMENT
+
+  "The address authorized for guardian interactions in the new Vault"
+  guardian: Bytes!
+  "The management address of the Vault to assert privileged functions that can only be called by management"
+  management: Bytes!
+  "The governance address of the Vault to assert privileged functions that can only be called by governance"
+  governance: Bytes!
+  
 }
 
 type HealthCheck @entity {
@@ -437,6 +458,20 @@ type Strategy @entity {
   reports: [StrategyReport!]! @derivedFrom(field: "strategy")
   "harvest() calls"
   harvests: [Harvest!]! @derivedFrom(field: "strategy")
+  "Used to track the deployed version of this contract"
+  apiVersion: String!
+  "Determines if strategy is in emergency exit"
+  emergencyExit: Boolean!
+  "Provide an accurate estimate for the total amount of assets (principle + return) that this Strategy is currently managing, denominated in terms of want tokens."
+  estimatedTotalAssets: BigInt!
+  "Provide an indication of whether this strategy is currently active"
+  isActive: Boolean!
+  "keeper is the only address that may call tend() or harvest(), other than governance() or strategist"
+  keeper: Bytes!
+  "The address of the strategist"
+  strategist: Bytes!
+  "The address for rewards"
+  rewards: Bytes!
 }
 
 type StrategyMigration @entity {

--- a/src/mappings/curveSETHVaultMappings.ts
+++ b/src/mappings/curveSETHVaultMappings.ts
@@ -1,10 +1,17 @@
-import { log } from '@graphprotocol/graph-ts';
+import { log, BigInt } from '@graphprotocol/graph-ts';
+import {
+  UpdateDepositLimit,
+  UpdateGovernance,
+  UpdateGuardian,
+  UpdateManagement,
+} from '../../generated/CurveSETHVault/Vault';
 import {
   Vault as VaultContract,
   UpdatePerformanceFee as UpdatePerformanceFeeEvent,
   UpdateManagementFee as UpdateManagementFeeEvent,
   StrategyAdded1 as StrategyAddedV2Event,
 } from '../../generated/Registry/Vault';
+import { Vault } from '../../generated/schema';
 import { isEventBlockNumberLt } from '../utils/commons';
 import {
   BIGINT_ZERO,
@@ -105,4 +112,53 @@ export function handleUpdateManagementFee(
       event.params.managementFee
     );
   }
+}
+
+export function handleUpdateGuardian(event: UpdateGuardian): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(event, 'UpdateGuardian');
+
+  vaultLibrary.handleUpdateGuardian(
+    event.address,
+    event.params.guardian,
+    ethTransaction
+  );
+}
+
+export function handleUpdateManagement(event: UpdateManagement): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(
+    event,
+    'UpdateManagement'
+  );
+
+  vaultLibrary.handleUpdateManagement(
+    event.address,
+    event.params.management,
+    ethTransaction
+  );
+}
+
+export function handleUpdateGovernance(event: UpdateGovernance): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(
+    event,
+    'UpdateGovernance'
+  );
+
+  vaultLibrary.handleUpdateGovernance(
+    event.address,
+    event.params.governance,
+    ethTransaction
+  );
+}
+
+export function handleUpdateDepositLimit(event: UpdateDepositLimit): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(
+    event,
+    'UpdateDepositLimit'
+  );
+
+  vaultLibrary.handleUpdateDepositLimit(
+    event.address,
+    event.params.depositLimit,
+    ethTransaction
+  );
 }

--- a/src/mappings/strategyMappings.ts
+++ b/src/mappings/strategyMappings.ts
@@ -1,4 +1,10 @@
-import { log } from '@graphprotocol/graph-ts';
+import {
+  ethereum,
+  log,
+  BigInt,
+  dataSource,
+  Address,
+} from '@graphprotocol/graph-ts';
 import {
   Harvested as HarvestedEvent,
   Cloned as ClonedEvent,
@@ -6,13 +12,21 @@ import {
   SetDoHealthCheckCall,
   SetHealthCheck as SetHealthCheckEvent,
   SetDoHealthCheck as SetDoHealthCheckEvent,
+  EmergencyExitEnabled,
+  UpdatedKeeper,
+  UpdatedStrategist,
+  UpdatedRewards,
 } from '../../generated/templates/Vault/Strategy';
+
+import { Vault as VaultContract } from '../../generated/templates/Vault/Vault';
 import * as strategyLibrary from '../utils/strategy/strategy';
 import {
   getOrCreateTransactionFromCall,
   getOrCreateTransactionFromEvent,
 } from '../utils/transaction';
 import { booleanToString } from '../utils/commons';
+import { UpdateRewards } from '../../generated/Registry/Vault';
+import { Strategy } from '../../generated/schema';
 
 export function handleSetHealthCheck(call: SetHealthCheckCall): void {
   let strategyAddress = call.to;
@@ -143,6 +157,48 @@ export function handleCloned(event: ClonedEvent): void {
   strategyLibrary.strategyCloned(
     clonedStrategyAddress,
     strategyAddress,
+    ethTransaction
+  );
+}
+
+export function handleEmergencyExitEnabled(event: EmergencyExitEnabled): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(
+    event,
+    'EmergencyExitEnabled'
+  );
+
+  strategyLibrary.emergencyExitEnabled(event.address, ethTransaction);
+}
+
+export function handleUpdatedKeeper(event: UpdatedKeeper): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(event, 'UpdatedKeeper');
+
+  strategyLibrary.updatedKeeper(
+    event.address,
+    event.params.newKeeper,
+    ethTransaction
+  );
+}
+
+export function handleUpdatedStrategist(event: UpdatedStrategist): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(
+    event,
+    'UpdatedStrategist'
+  );
+
+  strategyLibrary.updatedStrategist(
+    event.address,
+    event.params.newStrategist,
+    ethTransaction
+  );
+}
+
+export function handleUpdatedRewards(event: UpdatedRewards): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(event, 'UpdatedRewards');
+
+  strategyLibrary.updatedRewards(
+    event.address,
+    event.params.rewards,
     ethTransaction
   );
 }

--- a/src/mappings/vaultMappings.ts
+++ b/src/mappings/vaultMappings.ts
@@ -1,4 +1,4 @@
-import { log } from '@graphprotocol/graph-ts';
+import { BigInt, log } from '@graphprotocol/graph-ts';
 import {
   StrategyReported as StrategyReported_v0_3_0_v0_3_1_Event,
   StrategyMigrated as StrategyMigratedEvent,
@@ -24,8 +24,12 @@ import {
   StrategyRemovedFromQueue as StrategyRemovedFromQueueEvent,
   UpdateRewards as UpdateRewardsEvent,
   UpdateHealthCheck as UpdateHealthCheckEvent,
+  UpdateGuardian,
+  UpdateManagement,
+  UpdateGovernance,
+  UpdateDepositLimit,
 } from '../../generated/Registry/Vault';
-import { Strategy, StrategyMigration } from '../../generated/schema';
+import { Strategy, StrategyMigration, Vault } from '../../generated/schema';
 import { printCallInfo } from '../utils/commons';
 import { BIGINT_ZERO, BIGINT_MAX, ZERO_ADDRESS } from '../utils/constants';
 import * as strategyLibrary from '../utils/strategy/strategy';
@@ -565,6 +569,55 @@ export function handleTransfer(event: TransferEvent): void {
       ]
     );
   }
+}
+
+export function handleUpdateGuardian(event: UpdateGuardian): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(event, 'UpdateGuardian');
+
+  vaultLibrary.handleUpdateGuardian(
+    event.address,
+    event.params.guardian,
+    ethTransaction
+  );
+}
+
+export function handleUpdateManagement(event: UpdateManagement): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(
+    event,
+    'UpdateManagement'
+  );
+
+  vaultLibrary.handleUpdateManagement(
+    event.address,
+    event.params.management,
+    ethTransaction
+  );
+}
+
+export function handleUpdateGovernance(event: UpdateGovernance): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(
+    event,
+    'UpdateGovernance'
+  );
+
+  vaultLibrary.handleUpdateGovernance(
+    event.address,
+    event.params.governance,
+    ethTransaction
+  );
+}
+
+export function handleUpdateDepositLimit(event: UpdateDepositLimit): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(
+    event,
+    'UpdateDepositLimit'
+  );
+
+  vaultLibrary.handleUpdateDepositLimit(
+    event.address,
+    event.params.depositLimit,
+    ethTransaction
+  );
 }
 
 export function handleUpdatePerformanceFee(

--- a/src/mappings/yvLinkVaultMappings.ts
+++ b/src/mappings/yvLinkVaultMappings.ts
@@ -1,4 +1,4 @@
-import { Address, log } from '@graphprotocol/graph-ts';
+import { Address, log, BigInt } from '@graphprotocol/graph-ts';
 import { Vault as VaultContract } from '../../generated/Registry/Vault';
 import * as vaultLibrary from '../utils/vault/vault';
 import {
@@ -37,6 +37,12 @@ import {
   getOrCreateTransactionFromCall,
   getOrCreateTransactionFromEvent,
 } from '../utils/transaction';
+import {
+  UpdateDepositLimit,
+  UpdateGovernance,
+  UpdateGuardian,
+  UpdateManagement,
+} from '../../generated/YvLinkVault/Vault';
 
 function createYvLinkVaultIfNeeded(
   vaultAddress: Address,
@@ -775,4 +781,53 @@ export function handleUpdateRewards(event: UpdateRewardsEvent): void {
       ethTransaction
     );
   }
+}
+
+export function handleUpdateGuardian(event: UpdateGuardian): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(event, 'UpdateGuardian');
+
+  vaultLibrary.handleUpdateGuardian(
+    event.address,
+    event.params.guardian,
+    ethTransaction
+  );
+}
+
+export function handleUpdateManagement(event: UpdateManagement): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(
+    event,
+    'UpdateManagement'
+  );
+
+  vaultLibrary.handleUpdateManagement(
+    event.address,
+    event.params.management,
+    ethTransaction
+  );
+}
+
+export function handleUpdateGovernance(event: UpdateGovernance): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(
+    event,
+    'UpdateGovernance'
+  );
+
+  vaultLibrary.handleUpdateGovernance(
+    event.address,
+    event.params.governance,
+    ethTransaction
+  );
+}
+
+export function handleUpdateDepositLimit(event: UpdateDepositLimit): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(
+    event,
+    'UpdateDepositLimit'
+  );
+
+  vaultLibrary.handleUpdateDepositLimit(
+    event.address,
+    event.params.depositLimit,
+    ethTransaction
+  );
 }

--- a/src/mappings/yvWBTCVaultMappings.ts
+++ b/src/mappings/yvWBTCVaultMappings.ts
@@ -1,4 +1,4 @@
-import { Address, log } from '@graphprotocol/graph-ts';
+import { Address, log, BigInt } from '@graphprotocol/graph-ts';
 import { Vault as VaultContract } from '../../generated/Registry/Vault';
 import {
   StrategyReported as StrategyReported_v0_3_0_v0_3_1_Event,
@@ -19,6 +19,10 @@ import {
   StrategyAdded as StrategyAddedV1Event,
   StrategyAdded1 as StrategyAddedV2Event,
   UpdateRewards as UpdateRewardsEvent,
+  UpdateDepositLimit,
+  UpdateManagement,
+  UpdateGovernance,
+  UpdateGuardian,
 } from '../../generated/YvWBTCVault/Vault';
 import { Strategy, Transaction, Vault } from '../../generated/schema';
 import { isEventBlockNumberLt, printCallInfo } from '../utils/commons';
@@ -803,4 +807,53 @@ export function handleUpdateRewards(event: UpdateRewardsEvent): void {
       ethTransaction
     );
   }
+}
+
+export function handleUpdateGuardian(event: UpdateGuardian): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(event, 'UpdateGuardian');
+
+  vaultLibrary.handleUpdateGuardian(
+    event.address,
+    event.params.guardian,
+    ethTransaction
+  );
+}
+
+export function handleUpdateManagement(event: UpdateManagement): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(
+    event,
+    'UpdateManagement'
+  );
+
+  vaultLibrary.handleUpdateManagement(
+    event.address,
+    event.params.management,
+    ethTransaction
+  );
+}
+
+export function handleUpdateGovernance(event: UpdateGovernance): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(
+    event,
+    'UpdateGovernance'
+  );
+
+  vaultLibrary.handleUpdateGovernance(
+    event.address,
+    event.params.governance,
+    ethTransaction
+  );
+}
+
+export function handleUpdateDepositLimit(event: UpdateDepositLimit): void {
+  let ethTransaction = getOrCreateTransactionFromEvent(
+    event,
+    'UpdateDepositLimit'
+  );
+
+  vaultLibrary.handleUpdateDepositLimit(
+    event.address,
+    event.params.depositLimit,
+    ethTransaction
+  );
 }

--- a/src/utils/transfer.ts
+++ b/src/utils/transfer.ts
@@ -54,7 +54,6 @@ export function getOrCreate(
     toAccount,
     amount
   );
-
   let transfer = Transfer.load(id);
   if (transfer === null) {
     transfer = new Transfer(id);

--- a/src/utils/vault/vault.ts
+++ b/src/utils/vault/vault.ts
@@ -55,16 +55,31 @@ const createNewVaultFromAddress = (
   vaultEntity.balanceTokensIdle = BIGINT_ZERO;
   vaultEntity.balanceTokensInvested = BIGINT_ZERO;
 
-  vaultEntity.tokensDepositLimit = BIGINT_ZERO;
   vaultEntity.sharesSupply = BIGINT_ZERO;
   vaultEntity.managementFeeBps = vaultContract.managementFee().toI32();
   vaultEntity.performanceFeeBps = vaultContract.performanceFee().toI32();
-  vaultEntity.rewards = vaultContract.rewards();
+  let tryRewards = vaultContract.try_rewards();
+  vaultEntity.rewards = tryRewards.reverted ? Address.zero() : tryRewards.value;
 
-  // vaultEntity.tokensDepositLimit = vaultContract.depositLimit()
-  // vaultEntity.sharesSupply = vaultContract.totalSupply()
-  // vaultEntity.managementFeeBps = vaultContract.managementFee().toI32()
-  // vaultEntity.performanceFeeBps = vaultContract.performanceFee().toI32()
+  let tryManagement = vaultContract.try_management();
+  vaultEntity.management = tryManagement.reverted
+    ? Address.zero()
+    : tryManagement.value;
+
+  let tryGuardian = vaultContract.try_guardian();
+  vaultEntity.guardian = tryGuardian.reverted
+    ? Address.zero()
+    : tryGuardian.value;
+
+  let tryGovernance = vaultContract.try_governance();
+  vaultEntity.governance = tryGovernance.reverted
+    ? Address.zero()
+    : tryGovernance.value;
+
+  let tryDepositLimit = vaultContract.try_depositLimit();
+  vaultEntity.depositLimit = tryDepositLimit.reverted
+    ? BigInt.zero()
+    : tryDepositLimit.value;
 
   // vault fields
   vaultEntity.activation = vaultContract.activation();
@@ -663,5 +678,141 @@ export function handleUpdateHealthCheck(
     vault.save();
 
     vaultUpdateLibrary.healthCheckUpdated(vault, transaction, healthCheck.id);
+  }
+}
+
+export function handleUpdateGuardian(
+  vaultAddress: Address,
+  guardianAddress: Address,
+  transaction: Transaction
+): void {
+  let vault = Vault.load(vaultAddress.toHexString());
+  if (vault === null) {
+    log.warning(
+      'Failed to update vault guardian, vault does not exist. Vault address: {} guardian address: {}  Txn hash: {}',
+      [
+        vaultAddress.toHexString(),
+        guardianAddress.toHexString(),
+        transaction.hash.toHexString(),
+      ]
+    );
+    return;
+  } else {
+    log.info(
+      'Vault guardian updated. Vault address: {}, To: {}, on Txn hash: {}',
+      [
+        vaultAddress.toHexString(),
+        guardianAddress.toString(),
+        transaction.hash.toHexString(),
+      ]
+    );
+    vault.guardian = guardianAddress;
+    vault.save();
+  }
+}
+
+export function handleUpdateManagement(
+  vaultAddress: Address,
+  managementAddress: Address,
+  transaction: Transaction
+): void {
+  let vault = Vault.load(vaultAddress.toHexString());
+  if (vault === null) {
+    log.warning(
+      'Failed to update vault management, vault does not exist. Vault address: {} guardian address: {}  Txn hash: {}',
+      [
+        vaultAddress.toHexString(),
+        managementAddress.toHexString(),
+        transaction.hash.toHexString(),
+      ]
+    );
+    return;
+  } else {
+    log.info(
+      'Vault management updated. Vault address: {}, To: {}, on Txn hash: {}',
+      [
+        vaultAddress.toHexString(),
+        managementAddress.toString(),
+        transaction.hash.toHexString(),
+      ]
+    );
+
+    vault.management = managementAddress;
+    vault.save();
+  }
+}
+
+export function handleUpdateGovernance(
+  vaultAddress: Address,
+  governanceAddress: Address,
+  transaction: Transaction
+): void {
+  let vault = Vault.load(vaultAddress.toHexString());
+  if (vault === null) {
+    log.warning(
+      'Failed to update vault governance, vault does not exist. Vault address: {} guardian address: {}  Txn hash: {}',
+      [
+        vaultAddress.toHexString(),
+        governanceAddress.toHexString(),
+        transaction.hash.toHexString(),
+      ]
+    );
+    return;
+  } else {
+    log.info('Vault governance updated. Address: {}, To: {}, on Txn hash: {}', [
+      vaultAddress.toHexString(),
+      governanceAddress.toString(),
+      transaction.hash.toHexString(),
+    ]);
+
+    vault.governance = governanceAddress;
+    vault.save();
+  }
+}
+
+export function handleUpdateDepositLimit(
+  vaultAddress: Address,
+  depositLimit: BigInt,
+  transaction: Transaction
+): void {
+  let vault = Vault.load(vaultAddress.toHexString());
+  let vaultContract = VaultContract.bind(vaultAddress);
+  if (vault === null) {
+    log.warning(
+      'Failed to update vault deposit limit, vault does not exist. Vault address: {} deposit limit: {}  Txn hash: {}',
+      [
+        vaultAddress.toHexString(),
+        depositLimit.toString(),
+        transaction.hash.toHexString(),
+      ]
+    );
+    return;
+  } else {
+    log.info(
+      'Vault deposit limit updated. Address: {}, To: {}, on Txn hash: {}',
+      [
+        vaultAddress.toHexString(),
+        depositLimit.toString(),
+        transaction.hash.toHexString(),
+      ]
+    );
+
+    vault.depositLimit = depositLimit;
+    let tryAvailableDepositLimit = vaultContract.try_availableDepositLimit();
+    let availableDepositLimit = tryAvailableDepositLimit.reverted
+      ? BigInt.zero()
+      : tryAvailableDepositLimit.value;
+    vault.availableDepositLimit = availableDepositLimit;
+    if (
+      availableDepositLimit != BigInt.zero() &&
+      vault.depositLimit > availableDepositLimit
+    ) {
+      let tryTotalAssets = vaultContract.try_totalAssets();
+      let totalAssets = tryTotalAssets.reverted
+        ? BigInt.zero()
+        : tryTotalAssets.value;
+      vault.availableDepositLimit = vault.depositLimit.minus(totalAssets);
+    }
+    vault.save();
   }
 }

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -111,6 +111,14 @@ dataSources:
           # V2: StrategyAdded(strategy,debtRatio,minDebtPerHarvest,maxDebtPerHarvest,performanceFee)
         - event: StrategyAdded(indexed address,uint256,uint256,uint256,uint256)
           handler: handleStrategyAddedV2
+        - event: UpdateGuardian(address)
+          handler: handleUpdateGuardian
+        - event: UpdateManagement(address)
+          handler: handleUpdateManagement
+        - event: UpdateGovernance(address)
+          handler: handleUpdateGovernance
+        - event: UpdateDepositLimit(uint256)
+          handler: handleUpdateDepositLimit
       file: {{{mappingFile}}}
   {{/vaultsWithPreregisteredStrategies}}
 
@@ -185,6 +193,14 @@ dataSources:
           # V2: StrategyAdded(strategy,debtRatio,minDebtPerHarvest,maxDebtPerHarvest,performanceFee)
         - event: StrategyAdded(indexed address,uint256,uint256,uint256,uint256)
           handler: handleStrategyAddedV2
+        - event: UpdateGuardian(address)
+          handler: handleUpdateGuardian
+        - event: UpdateManagement(address)
+          handler: handleUpdateManagement
+        - event: UpdateGovernance(address)
+          handler: handleUpdateGovernance
+        - event: UpdateDepositLimit(uint256)
+          handler: handleUpdateDepositLimit
       {{#callHandlersEnabled}}
       callHandlers:
         - function: deposit()
@@ -273,6 +289,14 @@ templates:
           handler: handleStrategyAddedV2
         - event: UpdateHealthCheck(indexed address)
           handler: handleUpdateHealthCheck
+        - event: UpdateGuardian(address)
+          handler: handleUpdateGuardian
+        - event: UpdateManagement(address)
+          handler: handleUpdateManagement
+        - event: UpdateGovernance(address)
+          handler: handleUpdateGovernance
+        - event: UpdateDepositLimit(uint256)
+          handler: handleUpdateDepositLimit
       {{#callHandlersEnabled}}
       callHandlers:
         - function: deposit()
@@ -323,6 +347,14 @@ templates:
           handler: handleSetHealthCheckEvent
         - event: SetDoHealthCheck(bool)
           handler: handleSetDoHealthCheckEvent
+        - event: EmergencyExitEnabled()
+          handler: handleEmergencyExitEnabled
+        - event: UpdatedKeeper(address)
+          handler: handleUpdatedKeeper
+        - event: UpdatedStrategist(address)
+          handler: handleUpdatedStrategist
+        - event: UpdatedRewards(address)
+          handler: handleUpdatedRewards
       {{#callHandlersEnabled}}
       callHandlers:
         - function: setHealthCheck(address)

--- a/tests/default.ts
+++ b/tests/default.ts
@@ -51,4 +51,6 @@ export namespace defaults {
 
   export const strategyAddress = '0x3280499298ace3fd3cd9c2558e9e8746ace3e52d';
   export const strategistAddress = '0xea674fdde714fd979de3edf0f56aa9716b898ec8';
+  export const keeperAddress = '0x736d7e3c5a6cb2ce3b764300140abf476f6cfccf';
+  export const rewardsAddress = '0xc491599b9a20c3a2f0a85697ee6d9434efa9f503';
 }

--- a/tests/depositAndWithdrawl.test.ts
+++ b/tests/depositAndWithdrawl.test.ts
@@ -213,6 +213,11 @@ test('Deposit call handlers shouldnt fire if Vault apiVersion > 0.4.3', () => {
       null, // activation
       apiVersion, // apiVersion
       null, // rewardsAddress
+      null, // guardianAddress
+      null, // managementAddress
+      null, // governanceAddress
+      null, // depositLimit
+      null, // availableDepositLimit
       new TokenStub( //shareToken
         VaultStub.DefaultAddress, // token address
         null, // token name
@@ -278,6 +283,11 @@ test('Withdraw call handlers shouldnt fire if Vault apiVersion > 0.4.3', () => {
       null, // activation
       apiVersion, // apiVersion
       null, // rewardsAddress
+      null, // guardianAddress
+      null, // managementAddress
+      null, // governanceAddress
+      null, // depositLimit
+      null, // availableDepositLimit
       new TokenStub( //shareToken
         VaultStub.DefaultAddress, // token address
         null, // token name

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -24,6 +24,11 @@ test('Test handleNewRelease', () => {
     null, // activation
     null, // apiVersion
     null, // rewardsAddress
+    null, // guardianAddress
+    null, // managementAddress
+    null, // governanceAddress
+    null, // depositLimit
+    null, // availableDepositLimit
     TokenStub.DefaultToken(VaultStub.DefaultAddress), // shareToken
     TokenStub.DefaultToken(TokenStub.DefaultTokenAddress) // wantToken
   );

--- a/tests/strategy.test.ts
+++ b/tests/strategy.test.ts
@@ -1,4 +1,4 @@
-import { assert, clearStore, test } from 'matchstick-as/assembly/index';
+import { assert, clearStore, log, test } from 'matchstick-as/assembly/index';
 import { CreateVaultTransition } from './transitionMocks/createVaultTransition';
 import { defaults } from './default';
 import { handleStrategyReported_v0_3_0_v0_3_1 } from '../src/mappings/vaultMappings';
@@ -9,8 +9,12 @@ import {
 } from './transitionMocks/strategyTransitions';
 import { buildIdFromEvent } from '../src/utils/commons';
 import {
+  EmergencyExitTransition,
   SetDoHealthCheckTransition,
   SetHealthCheckTransition,
+  UpdatedKeeperTransition,
+  UpdatedRewardsTransition,
+  UpdatedStrategistTransition,
 } from './transitionMocks/strategyAttributeTransitions';
 import {
   handleSetDoHealthCheckEvent,
@@ -274,4 +278,84 @@ test('Test Strategy setDoHealthCheck Event', () => {
 
   // no-op to mark test for coverage
   handleSetDoHealthCheckEvent(setDoHealthCheckTransition.mockEvent.mock);
+});
+
+test('Test EmergencyExitEnabled Event', () => {
+  clearStore();
+
+  let vault = CreateVaultTransition.DefaultVault();
+  let strategy = CreateStrategyTransition.DefaultStrategy(vault.stub);
+  let strategyAddress = strategy.stub.address;
+
+  let oldEmergencyExit = strategy.stub.emergencyExit;
+  assert.fieldEquals(
+    'Strategy',
+    strategyAddress,
+    'emergencyExit',
+    oldEmergencyExit.toString()
+  );
+
+  let keeperUpdate = new EmergencyExitTransition(strategy.stub);
+  assert.fieldEquals('Strategy', strategyAddress, 'emergencyExit', 'true');
+});
+
+test('Test UpdatedKeeper Event', () => {
+  clearStore();
+
+  let vault = CreateVaultTransition.DefaultVault();
+  let strategy = CreateStrategyTransition.DefaultStrategy(vault.stub);
+  let strategyAddress = strategy.stub.address;
+
+  let oldKeeperAdress = strategy.stub.keeper;
+  assert.fieldEquals('Strategy', strategyAddress, 'keeper', oldKeeperAdress);
+
+  let newKeeper = defaults.senderAddress;
+  let keeperUpdate = new UpdatedKeeperTransition(strategy.stub, newKeeper);
+  assert.fieldEquals('Strategy', strategyAddress, 'keeper', newKeeper);
+});
+
+test('Test UpdatedStrategist Event', () => {
+  clearStore();
+
+  let vault = CreateVaultTransition.DefaultVault();
+  let strategy = CreateStrategyTransition.DefaultStrategy(vault.stub);
+  let strategyAddress = strategy.stub.address;
+
+  let oldStrategistAdress = strategy.stub.strategist;
+  assert.fieldEquals(
+    'Strategy',
+    strategyAddress,
+    'strategist',
+    oldStrategistAdress
+  );
+
+  let newStrategistAddress = defaults.senderAddress;
+  let strategistUpdate = new UpdatedStrategistTransition(
+    strategy.stub,
+    newStrategistAddress
+  );
+  assert.fieldEquals(
+    'Strategy',
+    strategyAddress,
+    'strategist',
+    newStrategistAddress
+  );
+});
+
+test('Test UpdatedRewards Event', () => {
+  clearStore();
+
+  let vault = CreateVaultTransition.DefaultVault();
+  let strategy = CreateStrategyTransition.DefaultStrategy(vault.stub);
+  let strategyAddress = strategy.stub.address;
+
+  let oldRewardsAdress = strategy.stub.rewards;
+  assert.fieldEquals('Strategy', strategyAddress, 'rewards', oldRewardsAdress);
+
+  let newRewardsAddress = defaults.senderAddress;
+  let rewardsUpdate = new UpdatedRewardsTransition(
+    strategy.stub,
+    newRewardsAddress
+  );
+  assert.fieldEquals('Strategy', strategyAddress, 'rewards', newRewardsAddress);
 });

--- a/tests/stubs/strategyStateStub.ts
+++ b/tests/stubs/strategyStateStub.ts
@@ -19,7 +19,10 @@ export class StrategyStub extends GenericStateStub {
       vaultStub.wantToken, // wantToken
       null, // health check
       false, // doHealthCheck
-      null // strategist
+      false, // emergencyExit
+      null, // strategist
+      null, // keeper
+      null // rewards
     );
   }
 
@@ -67,6 +70,15 @@ export class StrategyStub extends GenericStateStub {
     this._doHealthCheck = value;
   }
 
+  private _emergencyExit: boolean;
+  public get emergencyExit(): boolean {
+    return this._emergencyExit;
+  }
+  public set emergencyExit(value: boolean) {
+    this._updateStubField<boolean>('emergencyExit', value.toString());
+    this._emergencyExit = value;
+  }
+
   private _strategist: string;
   public get strategist(): string {
     return this._strategist;
@@ -94,6 +106,24 @@ export class StrategyStub extends GenericStateStub {
     this._vaultAddress = value;
   }
 
+  private _keeper: string;
+  public get keeper(): string {
+    return this._keeper;
+  }
+  public set keeper(value: string) {
+    this._updateStubField<Address>('keeper', value);
+    this._keeper = value;
+  }
+
+  private _rewards: string;
+  public get rewards(): string {
+    return this._rewards;
+  }
+  public set rewards(value: string) {
+    this._updateStubField<Address>('rewards', value);
+    this._rewards = value;
+  }
+
   //keeper: string;
   //delegatedAssets: string;
   //estimatedTotalAssets: string;
@@ -110,7 +140,10 @@ export class StrategyStub extends GenericStateStub {
       this.wantToken,
       this.healthCheck,
       this.doHealthCheck,
-      this.strategist
+      this.emergencyExit,
+      this.strategist,
+      this.keeper,
+      this.rewards
     );
   }
 
@@ -123,7 +156,10 @@ export class StrategyStub extends GenericStateStub {
     wantToken: TokenStub | null,
     healthCheck: string | null,
     doHealthCheck: boolean,
-    strategist: string | null
+    emergencyExit: boolean,
+    strategist: string | null,
+    keeper: string | null,
+    rewards: string | null
   ) {
     let _addressToUse = StrategyStub.DefaultAddress;
     if (address) {
@@ -160,6 +196,18 @@ export class StrategyStub extends GenericStateStub {
       this._strategist = defaults.strategistAddress;
     }
 
+    if (keeper) {
+      this._keeper = keeper;
+    } else {
+      this._keeper = defaults.keeperAddress;
+    }
+
+    if (rewards) {
+      this._rewards = rewards;
+    } else {
+      this._rewards = defaults.rewardsAddress;
+    }
+
     // figure out totalAssets by querying the wantToken balance
     if (this.wantToken.hasAccountBalance(this.address)) {
       this._totalAssets = this.wantToken.getAccountBalance(this.address);
@@ -175,7 +223,10 @@ export class StrategyStub extends GenericStateStub {
     this.healthCheck = this._healthCheck;
     this.doHealthCheck = this._doHealthCheck;
     this.strategist = this._strategist;
+    this.emergencyExit = this._emergencyExit;
     this.totalAssets = this._totalAssets;
+    this.keeper = this._keeper;
+    this.rewards = this._rewards;
 
     // these don't have setters so we directly update them
     this._updateStubField<Address>('token', this.wantToken.address);

--- a/tests/stubs/vaultStateStub.ts
+++ b/tests/stubs/vaultStateStub.ts
@@ -1,11 +1,12 @@
 import { Address, ethereum, BigInt } from '@graphprotocol/graph-ts';
-import { createMockedFunction, log } from 'matchstick-as';
+import { createMockedFunction } from 'matchstick-as';
 import { Vault } from '../../generated/Registry/Vault';
 import { Token } from '../../generated/schema';
 import { defaults } from '../default';
 import { fatalTestError } from '../util';
 import { GenericStateStub } from './genericStateStub';
 import { TokenStub } from './tokenStateStub';
+import { log } from 'matchstick-as/assembly/log';
 
 export class VaultStub extends GenericStateStub {
   static DefaultAddress: string = defaults.vaultAddress;
@@ -21,6 +22,11 @@ export class VaultStub extends GenericStateStub {
       null, // activation
       null, // apiVersion
       null, // rewards address
+      null, // guardian address
+      null, // management address
+      null, // governance address
+      null, // depositLimit
+      null, // availableDepositLimit
       TokenStub.DefaultToken(VaultStub.DefaultAddress),
       TokenStub.DefaultToken(TokenStub.DefaultTokenAddress)
     );
@@ -107,6 +113,51 @@ export class VaultStub extends GenericStateStub {
     this._rewardsAddress = value;
   }
 
+  private _guardianAddress: string;
+  public get guardianAddress(): string {
+    return this._guardianAddress;
+  }
+  public set guardianAddress(value: string) {
+    this._updateStubField<Address>('guardian', value);
+    this._guardianAddress = value;
+  }
+
+  private _managementAddress: string;
+  public get managementAddress(): string {
+    return this._managementAddress;
+  }
+  public set managementAddress(value: string) {
+    this._updateStubField<Address>('management', value);
+    this._managementAddress = value;
+  }
+
+  private _governanceAddress: string;
+  public get governanceAddress(): string {
+    return this._governanceAddress;
+  }
+  public set governanceAddress(value: string) {
+    this._updateStubField<Address>('governance', value);
+    this._governanceAddress = value;
+  }
+
+  private _depositLimit: string;
+  public get depositLimit(): string {
+    return this._depositLimit;
+  }
+  public set depositLimit(value: string) {
+    this._updateStubField<BigInt>('depositLimit', value);
+    this._depositLimit = value;
+  }
+
+  private _availableDepositLimit: string;
+  public get availableDepositLimit(): string {
+    return this._availableDepositLimit;
+  }
+  public set availableDepositLimit(value: string) {
+    this._updateStubField<BigInt>('availableDepositLimit', value);
+    this._availableDepositLimit = value;
+  }
+
   shareToken: TokenStub;
   wantToken: TokenStub;
 
@@ -121,6 +172,11 @@ export class VaultStub extends GenericStateStub {
       this.activation,
       this.apiVersion,
       this.rewardsAddress,
+      this.guardianAddress,
+      this.managementAddress,
+      this.governanceAddress,
+      this.depositLimit,
+      this.availableDepositLimit,
       this.shareToken,
       this.wantToken
     );
@@ -136,6 +192,11 @@ export class VaultStub extends GenericStateStub {
     activation: string | null,
     apiVersion: string | null,
     rewardsAddress: string | null,
+    guardianAddress: string | null,
+    managementAddress: string | null,
+    governanceAddress: string | null,
+    depositLimit: string | null,
+    availableDepositLimit: string | null,
     shareToken: TokenStub,
     wantToken: TokenStub
   ) {
@@ -188,6 +249,32 @@ export class VaultStub extends GenericStateStub {
     } else {
       this._rewardsAddress = defaults.treasuryAddress;
     }
+    if (guardianAddress) {
+      this._guardianAddress = guardianAddress;
+    } else {
+      this._guardianAddress = defaults.anotherAddress;
+    }
+    if (managementAddress) {
+      this._managementAddress = managementAddress;
+    } else {
+      // log.info(managementAddress, []);
+      this._managementAddress = defaults.anotherAddress;
+    }
+    if (governanceAddress) {
+      this._governanceAddress = governanceAddress;
+    } else {
+      this._governanceAddress = defaults.anotherAddress;
+    }
+    if (depositLimit) {
+      this._depositLimit = depositLimit;
+    } else {
+      this._depositLimit = '1000';
+    }
+    if (availableDepositLimit) {
+      this._availableDepositLimit = availableDepositLimit;
+    } else {
+      this._availableDepositLimit = '100';
+    }
 
     // update stubs by triggering each field's setter
     this.totalAssets = this._totalAssets;
@@ -198,9 +285,14 @@ export class VaultStub extends GenericStateStub {
     this.managementFee = this._managementFee;
     this.activation = this._activation;
     this.apiVersion = this._apiVersion;
+    this.depositLimit = this._depositLimit;
+    this.availableDepositLimit = this._availableDepositLimit;
 
     // these don't have setters so we directly update them
     this._updateStubField<Address>('token', this.wantToken.address);
     this._updateStubField<Address>('rewards', this.rewardsAddress);
+    this._updateStubField<Address>('guardian', this.guardianAddress);
+    this._updateStubField<Address>('management', this.managementAddress);
+    this._updateStubField<Address>('governance', this.governanceAddress);
   }
 }

--- a/tests/transitionMocks/createStrategyTransition.ts
+++ b/tests/transitionMocks/createStrategyTransition.ts
@@ -20,6 +20,9 @@ export class CreateStrategyTransition {
       vaultStub.wantToken,
       null,
       false,
+      false,
+      null,
+      null,
       null
     );
 
@@ -43,6 +46,9 @@ export class CreateStrategyTransition {
       null,
       true,
       vaultStub.wantToken,
+      null,
+      null,
+      false,
       null,
       null,
       null

--- a/tests/transitionMocks/createVaultTransition.ts
+++ b/tests/transitionMocks/createVaultTransition.ts
@@ -20,6 +20,11 @@ export class CreateVaultTransition {
         null, // activation
         null, // apiVersion
         null, // rewardsAddress
+        null, // guardianAddress
+        null, // managementAddress
+        null, // governanceAddress
+        null, // depositLimit
+        null, // availableDepositLimit
         new TokenStub( //shareToken
           VaultStub.DefaultAddress, // token address
           'DAI yVault', // token name
@@ -63,6 +68,11 @@ export class CreateVaultTransition {
       null, // activation
       null, // apiVersion
       null, // rewardsAddress
+      null, // guardianAddress
+      null, // managementAddress
+      null, // governanceAddress
+      null, // depositLimit
+      null, // availableDepositLimit
       new TokenStub( //shareToken
         VaultStub.DefaultAddress, // token address
         'DAI yVault', // token name
@@ -105,6 +115,12 @@ export class CreateVaultTransition {
       null, // activation
       null, // apiVersion
       null, // rewardsAddress
+      null, // guardianAddress
+      null, // managementAddress
+      null, // governanceAddress
+      null, // depositLimit
+      null, // availableDepositLimit
+
       new TokenStub( //shareToken
         VaultStub.DefaultAddress, // token address
         'DAI yVault', // token name
@@ -165,6 +181,11 @@ export class CreateVaultTransition {
         null, // activation
         null, // apiVersion
         null, // rewardsAddress
+        null, // guardianAddress
+        null, // managementAddress
+        null, // governanceAddress
+        null, // depositLimit
+        null, // availableDepositLimit
         shareToken, // shareToken
         wantToken // wantToken
       );

--- a/tests/transitionMocks/genericDepositTransition.ts
+++ b/tests/transitionMocks/genericDepositTransition.ts
@@ -87,8 +87,13 @@ export class GenericDepositTransition {
       preDepositStub.activation, // activation
       preDepositStub.apiVersion, // apiVersion
       preDepositStub.rewardsAddress, // rewardsAddress
-      newShareTokenStub.postTransitionStub,
-      newWantTokenStub.postTransitionStub
+      preDepositStub.guardianAddress, // guardianAddress
+      preDepositStub.managementAddress, // managementAddress
+      preDepositStub.governanceAddress, // governanceAddress
+      preDepositStub.depositLimit, // depositLimit
+      preDepositStub.availableDepositLimit, // availableDepositLimit
+      newShareTokenStub.postTransitionStub, // postTransitionStub
+      newWantTokenStub.postTransitionStub // postTransitionStub
     );
 
     // now trigger the transfer handlers that we skipped earlier

--- a/tests/transitionMocks/genericWithdrawTransition.ts
+++ b/tests/transitionMocks/genericWithdrawTransition.ts
@@ -64,6 +64,11 @@ export class GenericWithdrawTransition {
       preWithdrawStub.activation, // activation
       preWithdrawStub.apiVersion, // apiVersion
       preWithdrawStub.rewardsAddress, // rewardsAddress
+      preWithdrawStub.guardianAddress, // guardianAddress
+      preWithdrawStub.managementAddress, // managementAddress
+      preWithdrawStub.governanceAddress, // governanceAddress
+      preWithdrawStub.depositLimit, // depositLimit
+      preWithdrawStub.availableDepositLimit, // availableDepositLimit
       newShareTokenStub.postTransitionStub,
       newWantTokenStub.postTransitionStub
     );

--- a/tests/transitionMocks/strategyAttributeTransitions.ts
+++ b/tests/transitionMocks/strategyAttributeTransitions.ts
@@ -1,15 +1,25 @@
-import { Address } from '@graphprotocol/graph-ts';
+import { Address, BigInt } from '@graphprotocol/graph-ts';
 import { MockBlock } from '../mappingParamBuilders/mockBlock';
 import { GenericAttributeUpdateEvent } from '../mappingParamBuilders/genericUpdateParam';
 import {
+  EmergencyExitEnabled,
   SetDoHealthCheck,
   SetHealthCheck,
+  UpdatedKeeper,
+  UpdatedRewards,
+  UpdatedStrategist,
 } from '../../generated/templates/Vault/Strategy';
 import { StrategyStub } from '../stubs/strategyStateStub';
 import {
+  handleEmergencyExitEnabled,
   handleSetDoHealthCheckEvent,
   handleSetHealthCheckEvent,
+  handleUpdatedKeeper,
+  handleUpdatedRewards,
+  handleUpdatedStrategist,
 } from '../../src/mappings/strategyMappings';
+import { handleUpdateRewards } from '../../src/mappings/vaultMappings';
+import { MockTransaction } from '../mappingParamBuilders/mockTransaction';
 
 export class SetHealthCheckTransition {
   mockEvent: GenericAttributeUpdateEvent<SetHealthCheck, Address>;
@@ -56,6 +66,106 @@ export class SetDoHealthCheckTransition {
     );
 
     handleSetDoHealthCheckEvent(this.mockEvent.mock);
+
+    MockBlock.IncrementBlock();
+  }
+}
+
+export class UpdatedKeeperTransition {
+  mockEvent: GenericAttributeUpdateEvent<UpdatedKeeper, Address>;
+  preTransitionStub: StrategyStub;
+  postTransitionStub: StrategyStub;
+
+  constructor(preTransitionStub: StrategyStub, keeperAddress: string) {
+    this.preTransitionStub = preTransitionStub;
+
+    let postTransitionStub = preTransitionStub.clone();
+    postTransitionStub.keeper = keeperAddress;
+    this.postTransitionStub = postTransitionStub;
+
+    this.mockEvent = new GenericAttributeUpdateEvent<UpdatedKeeper, Address>(
+      preTransitionStub.address,
+      keeperAddress.toString(),
+      null,
+      null
+    );
+
+    handleUpdatedKeeper(this.mockEvent.mock);
+
+    MockBlock.IncrementBlock();
+  }
+}
+
+export class UpdatedStrategistTransition {
+  mockEvent: GenericAttributeUpdateEvent<UpdatedStrategist, Address>;
+  preTransitionStub: StrategyStub;
+  postTransitionStub: StrategyStub;
+
+  constructor(preTransitionStub: StrategyStub, strategistAddress: string) {
+    this.preTransitionStub = preTransitionStub;
+
+    let postTransitionStub = preTransitionStub.clone();
+    postTransitionStub.strategist = strategistAddress;
+    this.postTransitionStub = postTransitionStub;
+
+    this.mockEvent = new GenericAttributeUpdateEvent<
+      UpdatedStrategist,
+      Address
+    >(preTransitionStub.address, strategistAddress.toString(), null, null);
+
+    handleUpdatedStrategist(this.mockEvent.mock);
+
+    MockBlock.IncrementBlock();
+  }
+}
+
+export class UpdatedRewardsTransition {
+  mockEvent: GenericAttributeUpdateEvent<UpdatedRewards, Address>;
+  preTransitionStub: StrategyStub;
+  postTransitionStub: StrategyStub;
+
+  constructor(preTransitionStub: StrategyStub, rewardsAddress: string) {
+    this.preTransitionStub = preTransitionStub;
+
+    let postTransitionStub = preTransitionStub.clone();
+    postTransitionStub.rewards = rewardsAddress;
+    this.postTransitionStub = postTransitionStub;
+
+    this.mockEvent = new GenericAttributeUpdateEvent<UpdatedRewards, Address>(
+      preTransitionStub.address,
+      rewardsAddress.toString(),
+      null,
+      null
+    );
+
+    handleUpdatedRewards(this.mockEvent.mock);
+
+    MockBlock.IncrementBlock();
+  }
+}
+
+export class EmergencyExitTransition {
+  preTransitionStub: StrategyStub;
+  postTransitionStub: StrategyStub;
+
+  constructor(preTransitionStub: StrategyStub) {
+    this.preTransitionStub = preTransitionStub;
+
+    let postTransitionStub = preTransitionStub.clone();
+    postTransitionStub.emergencyExit = true;
+    this.postTransitionStub = postTransitionStub;
+
+    let event = instantiate<EmergencyExitEnabled>(
+      Address.fromString(preTransitionStub.address),
+      BigInt.fromString(MockTransaction.NewDefaultTxn().logIndex),
+      BigInt.fromString(MockTransaction.NewDefaultTxn().txnIndex),
+      'default_log_type',
+      MockBlock.NewDefaultBlock().mock,
+      MockTransaction.NewDefaultTxn().mock,
+      []
+    );
+
+    handleEmergencyExitEnabled(event);
 
     MockBlock.IncrementBlock();
   }

--- a/tests/transitionMocks/vaultAttributeTransitions.ts
+++ b/tests/transitionMocks/vaultAttributeTransitions.ts
@@ -1,5 +1,9 @@
 import { Address, BigInt, ethereum } from '@graphprotocol/graph-ts';
 import {
+  handleUpdateDepositLimit,
+  handleUpdateGovernance,
+  handleUpdateGuardian,
+  handleUpdateManagement,
   handleUpdateManagementFee,
   handleUpdatePerformanceFee,
   handleUpdateRewards,
@@ -7,6 +11,10 @@ import {
 import { MockBlock } from '../mappingParamBuilders/mockBlock';
 import { VaultStub } from '../stubs/vaultStateStub';
 import {
+  UpdateDepositLimit,
+  UpdateGovernance,
+  UpdateGuardian,
+  UpdateManagement,
   UpdateManagementFee,
   UpdatePerformanceFee,
   UpdateRewards,
@@ -79,6 +87,104 @@ export class MockUpdateRewardsTransition {
     );
 
     handleUpdateRewards(this.mockEvent.mock);
+
+    MockBlock.IncrementBlock();
+  }
+}
+
+export class MockUpdateGuardianTransition {
+  mockEvent: GenericAttributeUpdateEvent<UpdateGuardian, Address>;
+  preTransitionStub: VaultStub;
+  postTransitionStub: VaultStub;
+
+  constructor(preTransitionStub: VaultStub, newAddress: string) {
+    this.preTransitionStub = preTransitionStub;
+
+    let postTransitionStub = preTransitionStub.clone();
+    postTransitionStub.guardianAddress = newAddress;
+    this.postTransitionStub = postTransitionStub;
+
+    this.mockEvent = new GenericAttributeUpdateEvent<UpdateGuardian, Address>(
+      preTransitionStub.shareToken.address,
+      newAddress,
+      null,
+      null
+    );
+
+    handleUpdateGuardian(this.mockEvent.mock);
+
+    MockBlock.IncrementBlock();
+  }
+}
+
+export class MockUpdateManagementTransition {
+  mockEvent: GenericAttributeUpdateEvent<UpdateManagement, Address>;
+  preTransitionStub: VaultStub;
+  postTransitionStub: VaultStub;
+
+  constructor(preTransitionStub: VaultStub, newAddress: string) {
+    this.preTransitionStub = preTransitionStub;
+
+    let postTransitionStub = preTransitionStub.clone();
+    postTransitionStub.managementAddress = newAddress;
+    this.postTransitionStub = postTransitionStub;
+
+    this.mockEvent = new GenericAttributeUpdateEvent<UpdateManagement, Address>(
+      preTransitionStub.shareToken.address,
+      newAddress,
+      null,
+      null
+    );
+
+    handleUpdateManagement(this.mockEvent.mock);
+
+    MockBlock.IncrementBlock();
+  }
+}
+
+export class MockUpdateGovernanceTransition {
+  mockEvent: GenericAttributeUpdateEvent<UpdateGovernance, Address>;
+  preTransitionStub: VaultStub;
+  postTransitionStub: VaultStub;
+
+  constructor(preTransitionStub: VaultStub, newAddress: string) {
+    this.preTransitionStub = preTransitionStub;
+
+    let postTransitionStub = preTransitionStub.clone();
+    postTransitionStub.managementAddress = newAddress;
+    this.postTransitionStub = postTransitionStub;
+
+    this.mockEvent = new GenericAttributeUpdateEvent<UpdateGovernance, Address>(
+      preTransitionStub.shareToken.address,
+      newAddress,
+      null,
+      null
+    );
+
+    handleUpdateGovernance(this.mockEvent.mock);
+
+    MockBlock.IncrementBlock();
+  }
+}
+
+export class MockUpdateDepositLimitTransition {
+  mockEvent: GenericAttributeUpdateEvent<UpdateDepositLimit, BigInt>;
+  preTransitionStub: VaultStub;
+  postTransitionStub: VaultStub;
+
+  constructor(preTransitionStub: VaultStub, depositLimit: string) {
+    this.preTransitionStub = preTransitionStub;
+
+    let postTransitionStub = preTransitionStub.clone();
+    postTransitionStub.depositLimit = depositLimit;
+    this.postTransitionStub = postTransitionStub;
+
+    this.mockEvent = new GenericAttributeUpdateEvent<
+      UpdateDepositLimit,
+      BigInt
+    >(preTransitionStub.shareToken.address, depositLimit, null, null);
+
+    handleUpdateDepositLimit(this.mockEvent.mock);
 
     MockBlock.IncrementBlock();
   }

--- a/tests/vault.test.ts
+++ b/tests/vault.test.ts
@@ -3,12 +3,18 @@ import { CreateVaultTransition } from './transitionMocks/createVaultTransition';
 import { defaults } from './default';
 import {
   handleStrategyAddedV1,
+  handleUpdateGuardian,
+  handleUpdateManagement,
   handleUpdateManagementFee,
   handleUpdatePerformanceFee,
   handleUpdateRewards,
 } from '../src/mappings/vaultMappings';
 import {
+  MockUpdateDepositLimitTransition,
+  MockUpdateGovernanceTransition,
+  MockUpdateGuardianTransition,
   MockUpdateManagementFeeTransition,
+  MockUpdateManagementTransition,
   MockUpdatePerformanceFeeTransition,
   MockUpdateRewardsTransition,
 } from './transitionMocks/vaultAttributeTransitions';
@@ -142,4 +148,79 @@ test('Test handleStrategyAddedV1', () => {
 
   // intended to be null op for coverage detection
   handleStrategyAddedV1(strategy.mockEvent.mock);
+});
+
+test('Test UpdateGuardian Event', () => {
+  clearStore();
+
+  let vault = CreateVaultTransition.DefaultVault();
+  let vaultAddr = vault.stub.shareToken.address;
+
+  let oldGuardian = vault.stub.guardianAddress;
+  assert.fieldEquals('Vault', vaultAddr, 'guardian', oldGuardian);
+
+  let newGuardian = defaults.senderAddress;
+  let guardianUpdate = new MockUpdateGuardianTransition(
+    vault.stub,
+    newGuardian
+  );
+  assert.fieldEquals('Vault', vaultAddr!, 'guardian', newGuardian);
+});
+
+test('Test UpdateManagement Event', () => {
+  clearStore();
+
+  let vault = CreateVaultTransition.DefaultVault();
+  let vaultAddr = vault.stub.shareToken.address;
+
+  let oldManagement = vault.stub.managementAddress;
+  assert.fieldEquals('Vault', vaultAddr, 'management', oldManagement);
+
+  let newGuardian = defaults.senderAddress;
+  let managementUpdate = new MockUpdateManagementTransition(
+    vault.stub,
+    newGuardian
+  );
+  assert.fieldEquals('Vault', vaultAddr!, 'management', newGuardian);
+});
+
+test('Test UpdateGovernance Event', () => {
+  clearStore();
+
+  let vault = CreateVaultTransition.DefaultVault();
+  let vaultAddr = vault.stub.shareToken.address;
+
+  let oldGovernance = vault.stub.governanceAddress;
+  assert.fieldEquals('Vault', vaultAddr, 'governance', oldGovernance);
+
+  let newGovernance = defaults.senderAddress;
+  let governanceUpdate = new MockUpdateGovernanceTransition(
+    vault.stub,
+    newGovernance
+  );
+  assert.fieldEquals('Vault', vaultAddr!, 'governance', newGovernance);
+});
+
+test('Test UpdateDepositLimit Event', () => {
+  clearStore();
+
+  let vault = CreateVaultTransition.DefaultVault();
+  let vaultAddr = vault.stub.shareToken.address;
+
+  let oldDepositLimit = vault.stub.depositLimit;
+  assert.fieldEquals('Vault', vaultAddr, 'depositLimit', oldDepositLimit);
+
+  let newDepositLimit = '1000';
+  let newAvailableDepositLimit = '1000';
+  let depositLimitUpdate = new MockUpdateDepositLimitTransition(
+    vault.stub,
+    newDepositLimit
+  );
+  assert.fieldEquals('Vault', vaultAddr!, 'depositLimit', newDepositLimit);
+  assert.fieldEquals(
+    'Vault',
+    vaultAddr!,
+    'availableDepositLimit',
+    newAvailableDepositLimit
+  );
 });


### PR DESCRIPTION
https://github.com/yearn/yearn-vaults-v2-subgraph/issues/160

I'm not sure if my descriptions for some of these fields are accurate

1. availableDepositLimit - update on event UpdateDepositLimit but I did not update it on change to totalAssets because totalAssets is also a view method that is changed in many places
2. creditAvailable, debtOutstanding, expectedReturn - I did not add these due to the discussed issue. Also @weasel pointed out that arbitrum doesn't support block handler